### PR TITLE
Add alert role to error for screen readers

### DIFF
--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -10,7 +10,7 @@ const ErrorMessage: React.ComponentType<Props> = ({
   children,
   title = 'An unexpected error occurred'
 }) => (
-  <div className={styles.error}>
+  <div className={styles.error} role="alert">
     <div className={styles.title}>
       <h4>{title}</h4>
     </div>


### PR DESCRIPTION
This patch adds `role=alert` to our `<ErrorMessage>` component. This helps users of assistive technologies (eg screen readers) understand that _something bad_ happened when the `<ErrorMessage>` is rendered.

See https://www.w3.org/TR/WCAG20-TECHS/ARIA19.html